### PR TITLE
Add NASA Earthdata search_data and download tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added NASA Earthdata credentials block - [#4](https://github.com/giorgiobasile/prefect-eo/issues/4)
+- Added Prefect tasks to search and download data through NASA Earthdata - [#8](https://github.com/giorgiobasile/prefect-eo/issues/8)
 
 ### Changed
 
@@ -20,11 +21,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 ### Security
-
-## 0.1.0
-
-Released on ????? ?th, 20??.
-
-### Added
-
-- `task_name` task - [#1](https://github.com/giorgiobasile/prefect-eo/pull/1)

--- a/prefect_eo/earthdata.py
+++ b/prefect_eo/earthdata.py
@@ -1,8 +1,10 @@
 """Module handling NASA Earthdata credentials"""
 
 import os
+from typing import List
 
 import earthaccess
+from prefect import get_run_logger, task
 from prefect.blocks.core import Block
 from pydantic import Field, SecretStr
 
@@ -40,20 +42,144 @@ class EarthdataCredentials(Block):
 
     def login(self) -> earthaccess.Auth:
         """
-        Returns an authenticated session with NASA Earthdata
+        Returns an authenticated session with NASA Earthdata using
+        the [`earthaccess.login()`](https://nsidc.github.io/earthaccess/user-reference/api/api/#earthaccess.api.login) function
 
         Example:
+            Authenticates with NASA Earthdata using the credentials.
+
             ```python
+            from prefect_eo.earthdata import EarthdataCredentials
+
             earthdata_credentials_block = EarthdataCredentials(
                 earthdata_username = "username",
                 earthdata_password = "password"
             )
             earthdata_auth = earthdata_credentials_block.login()
             ```
-        """
-
-        """"""
+        """  # noqa E501
 
         os.environ["EARTHDATA_USERNAME"] = self.earthdata_username
         os.environ["EARTHDATA_PASSWORD"] = self.earthdata_password.get_secret_value()
         return earthaccess.login(strategy="environment")
+
+
+@task
+async def earthdata_search_data(
+    credentials: EarthdataCredentials, *args, **kwargs
+) -> List[earthaccess.results.DataGranule]:
+    """
+    Searches for data on NASA Earthdata using the
+    c function
+
+    Args:
+        credentials: An `EarthdataCredentials` object used
+            to authenticate with NASA Earthdata.
+        args: Additional positional arguments to be passed
+            to `earthaccess.search_data()`.
+        kwargs: Additional keyword arguments to be passed
+            to `earthaccess.search_data()`.
+
+    Returns:
+        A list of `DataGranule` objects representing the search results.
+
+    Example:
+        Searches granules through NASA Earthdata.
+
+        ```python
+        from prefect import flow
+        from prefect_eo.earthdata import EarthdataCredentials
+        from prefect_eo.earthdata import earthdata_search_data
+
+        @flow
+        def example_earthdata_search_flow():
+
+            credentials = EarthdataCredentials(
+                earthdata_userame = "username",
+                earthdata_password = "password"
+            )
+
+            search_results = earthdata_search_data(
+                earthdata_credentials,
+                count=1,
+                short_name="ATL08",
+                bounding_box=(-92.86, 16.26, -91.58, 16.97),
+            )
+            return search_results
+
+        example_earthdata_search_flow()
+        ```
+    """  # noqa: E501
+
+    logger = get_run_logger()
+
+    logger.debug("Authenticating to NASA Earthdata")
+    auth = credentials.login()
+    if not auth.authenticated:
+        raise ValueError("Could not authenticate to NASA Earthdata")
+
+    return earthaccess.search_data(*args, **kwargs)
+
+
+@task
+async def earthdata_download(
+    credentials: EarthdataCredentials, *args, **kwargs
+) -> List[str]:
+    """
+    Downloads data from NASA Earthdata using the
+    [`earthaccess.download()`](https://nsidc.github.io/earthaccess/user-reference/api/api/#earthaccess.api.download) function
+
+    Args:
+        credentials: An `EarthdataCredentials` object used
+            to authenticate with NASA Earthdata.
+        args: Additional positional arguments to be passed
+            to `earthaccess.download()`.
+        kwargs: Additional keyword arguments to be passed
+            to `earthaccess.download()`.
+
+    Returns:
+        A list of `DataGranule` objects representing the search results.
+
+    Example:
+        Searches and downloads granules through NASA Earthdata.
+
+        ```python
+        from prefect import flow
+        from prefect_eo.earthdata import EarthdataCredentials
+        from prefect_eo.earthdata import earthdata_search_data
+
+        @flow
+        def example_earthdata_download_flow():
+
+            credentials = EarthdataCredentials(
+                earthdata_userame = "username",
+                earthdata_password = "password"
+            )
+
+            search_results = earthdata_search_data(
+                earthdata_credentials,
+                count=1,
+                short_name="ATL08",
+                bounding_box=(-92.86, 16.26, -91.58, 16.97),
+            )
+
+            files = earthdata_download(
+                earthdata_credentials,
+                granules=granules,
+                local_path=download_path
+            )
+
+            return granules, files
+
+        example_earthdata_download_flow()
+        ```
+    """  # noqa: E501
+
+    logger = get_run_logger()
+
+    logger.debug("Authenticating to NASA Earthdata")
+    auth = credentials.login()
+    if not auth.authenticated:
+        raise ValueError("Could not authenticate to NASA Earthdata")
+
+    return earthaccess.download(*args, **kwargs)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,3 +13,4 @@ interrogate
 coverage
 pillow
 requests_mock
+importlib_resources

--- a/tests/data/earthdata_search_response.json
+++ b/tests/data/earthdata_search_response.json
@@ -1,0 +1,431 @@
+{
+  "hits": 760,
+  "took": 1450,
+  "items": [
+    {
+      "meta": {
+        "concept-type": "granule",
+        "concept-id": "G2166695839-NSIDC_CPRD",
+        "revision-id": 1,
+        "native-id": "ATL08_20181105083647_05760107_005_01.h5",
+        "provider-id": "NSIDC_CPRD",
+        "format": "application/iso:smap+xml",
+        "revision-date": "2021-11-16T00:43:39.912Z"
+      },
+      "umm": {
+        "TemporalExtent": {
+          "RangeDateTime": {
+            "BeginningDateTime": "2018-11-05T08:38:40.137Z",
+            "EndingDateTime": "2018-11-05T08:40:18.214Z"
+          }
+        },
+        "OrbitCalculatedSpatialDomains": [
+          {
+            "OrbitNumber": 777,
+            "EquatorCrossingLongitude": 98.76096834651058,
+            "EquatorCrossingDateTime": "2018-11-05T07:56:47.707Z"
+          }
+        ],
+        "GranuleUR": "ATL08_20181105083647_05760107_005_01.h5",
+        "SpatialExtent": {
+          "HorizontalSpatialDomain": {
+            "Orbit": {
+              "AscendingCrossing": 98.76096834651058,
+              "StartLatitude": 27.0,
+              "StartDirection": "D",
+              "EndLatitude": 0.0,
+              "EndDirection": "D"
+            }
+          }
+        },
+        "ProviderDates": [
+          {
+            "Date": "2021-11-16T00:43:38.395Z",
+            "Type": "Insert"
+          },
+          {
+            "Date": "2021-11-16T00:43:38.395Z",
+            "Type": "Update"
+          }
+        ],
+        "CollectionReference": {
+          "EntryTitle": "ATLAS/ICESat-2 L3A Land and Vegetation Height V005"
+        },
+        "RelatedUrls": [
+          {
+            "URL": "https://data.nsidc.earthdatacloud.nasa.gov/nsidc-cumulus-prod-protected/ATLAS/ATL08/005/2018/11/05/ATL08_20181105083647_05760107_005_01.h5",
+            "Type": "GET DATA",
+            "MimeType": "application/x-hdf5"
+          },
+          {
+            "URL": "https://data.nsidc.earthdatacloud.nasa.gov/nsidc-cumulus-prod-protected/ATLAS/ATL08/005/2018/11/05/ATL08_20181105083647_05760107_005_01.h5.dmrpp",
+            "Type": "VIEW RELATED INFORMATION",
+            "MimeType": "none"
+          },
+          {
+            "URL": "https://data.nsidc.earthdatacloud.nasa.gov/nsidc-cumulus-prod-public/ATLAS/ATL08/005/2018/11/05/ATL08_20181105083647_05760107_005_01.iso.xml",
+            "Type": "VIEW RELATED INFORMATION",
+            "MimeType": "text/xml"
+          },
+          {
+            "URL": "https://data.nsidc.earthdatacloud.nasa.gov/nsidc-cumulus-prod-public/ATLAS/ATL08/005/2018/11/05/ATL08_20181105083647_05760107_005_01_BRW.default.default1.jpg",
+            "Type": "GET RELATED VISUALIZATION",
+            "MimeType": "image/jpeg"
+          },
+          {
+            "URL": "https://data.nsidc.earthdatacloud.nasa.gov/nsidc-cumulus-prod-public/ATLAS/ATL08/005/2018/11/05/ATL08_20181105083647_05760107_005_01_BRW.default.default2.jpg",
+            "Type": "GET RELATED VISUALIZATION",
+            "MimeType": "image/jpeg"
+          },
+          {
+            "URL": "https://data.nsidc.earthdatacloud.nasa.gov/nsidc-cumulus-prod-public/ATLAS/ATL08/005/2018/11/05/ATL08_20181105083647_05760107_005_01_BRW.gt1l.groundtrack.jpg",
+            "Type": "GET RELATED VISUALIZATION",
+            "MimeType": "image/jpeg"
+          },
+          {
+            "URL": "https://data.nsidc.earthdatacloud.nasa.gov/nsidc-cumulus-prod-public/ATLAS/ATL08/005/2018/11/05/ATL08_20181105083647_05760107_005_01_BRW.gt1l.h_canopy_abs.jpg",
+            "Type": "GET RELATED VISUALIZATION",
+            "MimeType": "image/jpeg"
+          },
+          {
+            "URL": "https://data.nsidc.earthdatacloud.nasa.gov/nsidc-cumulus-prod-public/ATLAS/ATL08/005/2018/11/05/ATL08_20181105083647_05760107_005_01_BRW.gt1l.h_te_median.jpg",
+            "Type": "GET RELATED VISUALIZATION",
+            "MimeType": "image/jpeg"
+          },
+          {
+            "URL": "https://data.nsidc.earthdatacloud.nasa.gov/nsidc-cumulus-prod-public/ATLAS/ATL08/005/2018/11/05/ATL08_20181105083647_05760107_005_01_BRW.gt1l.n_ca_photons.jpg",
+            "Type": "GET RELATED VISUALIZATION",
+            "MimeType": "image/jpeg"
+          },
+          {
+            "URL": "https://data.nsidc.earthdatacloud.nasa.gov/nsidc-cumulus-prod-public/ATLAS/ATL08/005/2018/11/05/ATL08_20181105083647_05760107_005_01_BRW.gt1l.n_te_photons.jpg",
+            "Type": "GET RELATED VISUALIZATION",
+            "MimeType": "image/jpeg"
+          },
+          {
+            "URL": "https://data.nsidc.earthdatacloud.nasa.gov/nsidc-cumulus-prod-public/ATLAS/ATL08/005/2018/11/05/ATL08_20181105083647_05760107_005_01_BRW.gt1r.groundtrack.jpg",
+            "Type": "GET RELATED VISUALIZATION",
+            "MimeType": "image/jpeg"
+          },
+          {
+            "URL": "https://data.nsidc.earthdatacloud.nasa.gov/nsidc-cumulus-prod-public/ATLAS/ATL08/005/2018/11/05/ATL08_20181105083647_05760107_005_01_BRW.gt1r.h_canopy_abs.jpg",
+            "Type": "GET RELATED VISUALIZATION",
+            "MimeType": "image/jpeg"
+          },
+          {
+            "URL": "https://data.nsidc.earthdatacloud.nasa.gov/nsidc-cumulus-prod-public/ATLAS/ATL08/005/2018/11/05/ATL08_20181105083647_05760107_005_01_BRW.gt1r.h_te_median.jpg",
+            "Type": "GET RELATED VISUALIZATION",
+            "MimeType": "image/jpeg"
+          },
+          {
+            "URL": "https://data.nsidc.earthdatacloud.nasa.gov/nsidc-cumulus-prod-public/ATLAS/ATL08/005/2018/11/05/ATL08_20181105083647_05760107_005_01_BRW.gt1r.n_ca_photons.jpg",
+            "Type": "GET RELATED VISUALIZATION",
+            "MimeType": "image/jpeg"
+          },
+          {
+            "URL": "https://data.nsidc.earthdatacloud.nasa.gov/nsidc-cumulus-prod-public/ATLAS/ATL08/005/2018/11/05/ATL08_20181105083647_05760107_005_01_BRW.gt1r.n_te_photons.jpg",
+            "Type": "GET RELATED VISUALIZATION",
+            "MimeType": "image/jpeg"
+          },
+          {
+            "URL": "https://data.nsidc.earthdatacloud.nasa.gov/nsidc-cumulus-prod-public/ATLAS/ATL08/005/2018/11/05/ATL08_20181105083647_05760107_005_01_BRW.gt2l.groundtrack.jpg",
+            "Type": "GET RELATED VISUALIZATION",
+            "MimeType": "image/jpeg"
+          },
+          {
+            "URL": "https://data.nsidc.earthdatacloud.nasa.gov/nsidc-cumulus-prod-public/ATLAS/ATL08/005/2018/11/05/ATL08_20181105083647_05760107_005_01_BRW.gt2l.h_canopy_abs.jpg",
+            "Type": "GET RELATED VISUALIZATION",
+            "MimeType": "image/jpeg"
+          },
+          {
+            "URL": "https://data.nsidc.earthdatacloud.nasa.gov/nsidc-cumulus-prod-public/ATLAS/ATL08/005/2018/11/05/ATL08_20181105083647_05760107_005_01_BRW.gt2l.h_te_median.jpg",
+            "Type": "GET RELATED VISUALIZATION",
+            "MimeType": "image/jpeg"
+          },
+          {
+            "URL": "https://data.nsidc.earthdatacloud.nasa.gov/nsidc-cumulus-prod-public/ATLAS/ATL08/005/2018/11/05/ATL08_20181105083647_05760107_005_01_BRW.gt2l.n_ca_photons.jpg",
+            "Type": "GET RELATED VISUALIZATION",
+            "MimeType": "image/jpeg"
+          },
+          {
+            "URL": "https://data.nsidc.earthdatacloud.nasa.gov/nsidc-cumulus-prod-public/ATLAS/ATL08/005/2018/11/05/ATL08_20181105083647_05760107_005_01_BRW.gt2l.n_te_photons.jpg",
+            "Type": "GET RELATED VISUALIZATION",
+            "MimeType": "image/jpeg"
+          },
+          {
+            "URL": "https://data.nsidc.earthdatacloud.nasa.gov/nsidc-cumulus-prod-public/ATLAS/ATL08/005/2018/11/05/ATL08_20181105083647_05760107_005_01_BRW.gt2r.groundtrack.jpg",
+            "Type": "GET RELATED VISUALIZATION",
+            "MimeType": "image/jpeg"
+          },
+          {
+            "URL": "https://data.nsidc.earthdatacloud.nasa.gov/nsidc-cumulus-prod-public/ATLAS/ATL08/005/2018/11/05/ATL08_20181105083647_05760107_005_01_BRW.gt2r.h_canopy_abs.jpg",
+            "Type": "GET RELATED VISUALIZATION",
+            "MimeType": "image/jpeg"
+          },
+          {
+            "URL": "https://data.nsidc.earthdatacloud.nasa.gov/nsidc-cumulus-prod-public/ATLAS/ATL08/005/2018/11/05/ATL08_20181105083647_05760107_005_01_BRW.gt2r.h_te_median.jpg",
+            "Type": "GET RELATED VISUALIZATION",
+            "MimeType": "image/jpeg"
+          },
+          {
+            "URL": "https://data.nsidc.earthdatacloud.nasa.gov/nsidc-cumulus-prod-public/ATLAS/ATL08/005/2018/11/05/ATL08_20181105083647_05760107_005_01_BRW.gt2r.n_ca_photons.jpg",
+            "Type": "GET RELATED VISUALIZATION",
+            "MimeType": "image/jpeg"
+          },
+          {
+            "URL": "https://data.nsidc.earthdatacloud.nasa.gov/nsidc-cumulus-prod-public/ATLAS/ATL08/005/2018/11/05/ATL08_20181105083647_05760107_005_01_BRW.gt2r.n_te_photons.jpg",
+            "Type": "GET RELATED VISUALIZATION",
+            "MimeType": "image/jpeg"
+          },
+          {
+            "URL": "https://data.nsidc.earthdatacloud.nasa.gov/nsidc-cumulus-prod-public/ATLAS/ATL08/005/2018/11/05/ATL08_20181105083647_05760107_005_01_BRW.gt3l.groundtrack.jpg",
+            "Type": "GET RELATED VISUALIZATION",
+            "MimeType": "image/jpeg"
+          },
+          {
+            "URL": "https://data.nsidc.earthdatacloud.nasa.gov/nsidc-cumulus-prod-public/ATLAS/ATL08/005/2018/11/05/ATL08_20181105083647_05760107_005_01_BRW.gt3l.h_canopy_abs.jpg",
+            "Type": "GET RELATED VISUALIZATION",
+            "MimeType": "image/jpeg"
+          },
+          {
+            "URL": "https://data.nsidc.earthdatacloud.nasa.gov/nsidc-cumulus-prod-public/ATLAS/ATL08/005/2018/11/05/ATL08_20181105083647_05760107_005_01_BRW.gt3l.h_te_median.jpg",
+            "Type": "GET RELATED VISUALIZATION",
+            "MimeType": "image/jpeg"
+          },
+          {
+            "URL": "https://data.nsidc.earthdatacloud.nasa.gov/nsidc-cumulus-prod-public/ATLAS/ATL08/005/2018/11/05/ATL08_20181105083647_05760107_005_01_BRW.gt3l.n_ca_photons.jpg",
+            "Type": "GET RELATED VISUALIZATION",
+            "MimeType": "image/jpeg"
+          },
+          {
+            "URL": "https://data.nsidc.earthdatacloud.nasa.gov/nsidc-cumulus-prod-public/ATLAS/ATL08/005/2018/11/05/ATL08_20181105083647_05760107_005_01_BRW.gt3l.n_te_photons.jpg",
+            "Type": "GET RELATED VISUALIZATION",
+            "MimeType": "image/jpeg"
+          },
+          {
+            "URL": "https://data.nsidc.earthdatacloud.nasa.gov/nsidc-cumulus-prod-public/ATLAS/ATL08/005/2018/11/05/ATL08_20181105083647_05760107_005_01_BRW.gt3r.groundtrack.jpg",
+            "Type": "GET RELATED VISUALIZATION",
+            "MimeType": "image/jpeg"
+          },
+          {
+            "URL": "https://data.nsidc.earthdatacloud.nasa.gov/nsidc-cumulus-prod-public/ATLAS/ATL08/005/2018/11/05/ATL08_20181105083647_05760107_005_01_BRW.gt3r.h_canopy_abs.jpg",
+            "Type": "GET RELATED VISUALIZATION",
+            "MimeType": "image/jpeg"
+          },
+          {
+            "URL": "https://data.nsidc.earthdatacloud.nasa.gov/nsidc-cumulus-prod-public/ATLAS/ATL08/005/2018/11/05/ATL08_20181105083647_05760107_005_01_BRW.gt3r.h_te_median.jpg",
+            "Type": "GET RELATED VISUALIZATION",
+            "MimeType": "image/jpeg"
+          },
+          {
+            "URL": "https://data.nsidc.earthdatacloud.nasa.gov/nsidc-cumulus-prod-public/ATLAS/ATL08/005/2018/11/05/ATL08_20181105083647_05760107_005_01_BRW.gt3r.n_ca_photons.jpg",
+            "Type": "GET RELATED VISUALIZATION",
+            "MimeType": "image/jpeg"
+          },
+          {
+            "URL": "https://data.nsidc.earthdatacloud.nasa.gov/nsidc-cumulus-prod-public/ATLAS/ATL08/005/2018/11/05/ATL08_20181105083647_05760107_005_01_BRW.gt3r.n_te_photons.jpg",
+            "Type": "GET RELATED VISUALIZATION",
+            "MimeType": "image/jpeg"
+          },
+          {
+            "URL": "s3://nsidc-cumulus-prod-protected/ATLAS/ATL08/005/2018/11/05/ATL08_20181105083647_05760107_005_01.h5",
+            "Type": "GET DATA VIA DIRECT ACCESS",
+            "MimeType": "application/x-hdf5"
+          },
+          {
+            "URL": "s3://nsidc-cumulus-prod-protected/ATLAS/ATL08/005/2018/11/05/ATL08_20181105083647_05760107_005_01.h5.dmrpp",
+            "Type": "VIEW RELATED INFORMATION",
+            "MimeType": "none"
+          },
+          {
+            "URL": "s3://nsidc-cumulus-prod-public/ATLAS/ATL08/005/2018/11/05/ATL08_20181105083647_05760107_005_01.iso.xml",
+            "Type": "VIEW RELATED INFORMATION",
+            "MimeType": "text/xml"
+          },
+          {
+            "URL": "s3://nsidc-cumulus-prod-public/ATLAS/ATL08/005/2018/11/05/ATL08_20181105083647_05760107_005_01_BRW.default.default1.jpg",
+            "Type": "GET RELATED VISUALIZATION",
+            "MimeType": "image/jpeg"
+          },
+          {
+            "URL": "s3://nsidc-cumulus-prod-public/ATLAS/ATL08/005/2018/11/05/ATL08_20181105083647_05760107_005_01_BRW.default.default2.jpg",
+            "Type": "GET RELATED VISUALIZATION",
+            "MimeType": "image/jpeg"
+          },
+          {
+            "URL": "s3://nsidc-cumulus-prod-public/ATLAS/ATL08/005/2018/11/05/ATL08_20181105083647_05760107_005_01_BRW.gt1l.groundtrack.jpg",
+            "Type": "GET RELATED VISUALIZATION",
+            "MimeType": "image/jpeg"
+          },
+          {
+            "URL": "s3://nsidc-cumulus-prod-public/ATLAS/ATL08/005/2018/11/05/ATL08_20181105083647_05760107_005_01_BRW.gt1l.h_canopy_abs.jpg",
+            "Type": "GET RELATED VISUALIZATION",
+            "MimeType": "image/jpeg"
+          },
+          {
+            "URL": "s3://nsidc-cumulus-prod-public/ATLAS/ATL08/005/2018/11/05/ATL08_20181105083647_05760107_005_01_BRW.gt1l.h_te_median.jpg",
+            "Type": "GET RELATED VISUALIZATION",
+            "MimeType": "image/jpeg"
+          },
+          {
+            "URL": "s3://nsidc-cumulus-prod-public/ATLAS/ATL08/005/2018/11/05/ATL08_20181105083647_05760107_005_01_BRW.gt1l.n_ca_photons.jpg",
+            "Type": "GET RELATED VISUALIZATION",
+            "MimeType": "image/jpeg"
+          },
+          {
+            "URL": "s3://nsidc-cumulus-prod-public/ATLAS/ATL08/005/2018/11/05/ATL08_20181105083647_05760107_005_01_BRW.gt1l.n_te_photons.jpg",
+            "Type": "GET RELATED VISUALIZATION",
+            "MimeType": "image/jpeg"
+          },
+          {
+            "URL": "s3://nsidc-cumulus-prod-public/ATLAS/ATL08/005/2018/11/05/ATL08_20181105083647_05760107_005_01_BRW.gt1r.groundtrack.jpg",
+            "Type": "GET RELATED VISUALIZATION",
+            "MimeType": "image/jpeg"
+          },
+          {
+            "URL": "s3://nsidc-cumulus-prod-public/ATLAS/ATL08/005/2018/11/05/ATL08_20181105083647_05760107_005_01_BRW.gt1r.h_canopy_abs.jpg",
+            "Type": "GET RELATED VISUALIZATION",
+            "MimeType": "image/jpeg"
+          },
+          {
+            "URL": "s3://nsidc-cumulus-prod-public/ATLAS/ATL08/005/2018/11/05/ATL08_20181105083647_05760107_005_01_BRW.gt1r.h_te_median.jpg",
+            "Type": "GET RELATED VISUALIZATION",
+            "MimeType": "image/jpeg"
+          },
+          {
+            "URL": "s3://nsidc-cumulus-prod-public/ATLAS/ATL08/005/2018/11/05/ATL08_20181105083647_05760107_005_01_BRW.gt1r.n_ca_photons.jpg",
+            "Type": "GET RELATED VISUALIZATION",
+            "MimeType": "image/jpeg"
+          },
+          {
+            "URL": "s3://nsidc-cumulus-prod-public/ATLAS/ATL08/005/2018/11/05/ATL08_20181105083647_05760107_005_01_BRW.gt1r.n_te_photons.jpg",
+            "Type": "GET RELATED VISUALIZATION",
+            "MimeType": "image/jpeg"
+          },
+          {
+            "URL": "s3://nsidc-cumulus-prod-public/ATLAS/ATL08/005/2018/11/05/ATL08_20181105083647_05760107_005_01_BRW.gt2l.groundtrack.jpg",
+            "Type": "GET RELATED VISUALIZATION",
+            "MimeType": "image/jpeg"
+          },
+          {
+            "URL": "s3://nsidc-cumulus-prod-public/ATLAS/ATL08/005/2018/11/05/ATL08_20181105083647_05760107_005_01_BRW.gt2l.h_canopy_abs.jpg",
+            "Type": "GET RELATED VISUALIZATION",
+            "MimeType": "image/jpeg"
+          },
+          {
+            "URL": "s3://nsidc-cumulus-prod-public/ATLAS/ATL08/005/2018/11/05/ATL08_20181105083647_05760107_005_01_BRW.gt2l.h_te_median.jpg",
+            "Type": "GET RELATED VISUALIZATION",
+            "MimeType": "image/jpeg"
+          },
+          {
+            "URL": "s3://nsidc-cumulus-prod-public/ATLAS/ATL08/005/2018/11/05/ATL08_20181105083647_05760107_005_01_BRW.gt2l.n_ca_photons.jpg",
+            "Type": "GET RELATED VISUALIZATION",
+            "MimeType": "image/jpeg"
+          },
+          {
+            "URL": "s3://nsidc-cumulus-prod-public/ATLAS/ATL08/005/2018/11/05/ATL08_20181105083647_05760107_005_01_BRW.gt2l.n_te_photons.jpg",
+            "Type": "GET RELATED VISUALIZATION",
+            "MimeType": "image/jpeg"
+          },
+          {
+            "URL": "s3://nsidc-cumulus-prod-public/ATLAS/ATL08/005/2018/11/05/ATL08_20181105083647_05760107_005_01_BRW.gt2r.groundtrack.jpg",
+            "Type": "GET RELATED VISUALIZATION",
+            "MimeType": "image/jpeg"
+          },
+          {
+            "URL": "s3://nsidc-cumulus-prod-public/ATLAS/ATL08/005/2018/11/05/ATL08_20181105083647_05760107_005_01_BRW.gt2r.h_canopy_abs.jpg",
+            "Type": "GET RELATED VISUALIZATION",
+            "MimeType": "image/jpeg"
+          },
+          {
+            "URL": "s3://nsidc-cumulus-prod-public/ATLAS/ATL08/005/2018/11/05/ATL08_20181105083647_05760107_005_01_BRW.gt2r.h_te_median.jpg",
+            "Type": "GET RELATED VISUALIZATION",
+            "MimeType": "image/jpeg"
+          },
+          {
+            "URL": "s3://nsidc-cumulus-prod-public/ATLAS/ATL08/005/2018/11/05/ATL08_20181105083647_05760107_005_01_BRW.gt2r.n_ca_photons.jpg",
+            "Type": "GET RELATED VISUALIZATION",
+            "MimeType": "image/jpeg"
+          },
+          {
+            "URL": "s3://nsidc-cumulus-prod-public/ATLAS/ATL08/005/2018/11/05/ATL08_20181105083647_05760107_005_01_BRW.gt2r.n_te_photons.jpg",
+            "Type": "GET RELATED VISUALIZATION",
+            "MimeType": "image/jpeg"
+          },
+          {
+            "URL": "s3://nsidc-cumulus-prod-public/ATLAS/ATL08/005/2018/11/05/ATL08_20181105083647_05760107_005_01_BRW.gt3l.groundtrack.jpg",
+            "Type": "GET RELATED VISUALIZATION",
+            "MimeType": "image/jpeg"
+          },
+          {
+            "URL": "s3://nsidc-cumulus-prod-public/ATLAS/ATL08/005/2018/11/05/ATL08_20181105083647_05760107_005_01_BRW.gt3l.h_canopy_abs.jpg",
+            "Type": "GET RELATED VISUALIZATION",
+            "MimeType": "image/jpeg"
+          },
+          {
+            "URL": "s3://nsidc-cumulus-prod-public/ATLAS/ATL08/005/2018/11/05/ATL08_20181105083647_05760107_005_01_BRW.gt3l.h_te_median.jpg",
+            "Type": "GET RELATED VISUALIZATION",
+            "MimeType": "image/jpeg"
+          },
+          {
+            "URL": "s3://nsidc-cumulus-prod-public/ATLAS/ATL08/005/2018/11/05/ATL08_20181105083647_05760107_005_01_BRW.gt3l.n_ca_photons.jpg",
+            "Type": "GET RELATED VISUALIZATION",
+            "MimeType": "image/jpeg"
+          },
+          {
+            "URL": "s3://nsidc-cumulus-prod-public/ATLAS/ATL08/005/2018/11/05/ATL08_20181105083647_05760107_005_01_BRW.gt3l.n_te_photons.jpg",
+            "Type": "GET RELATED VISUALIZATION",
+            "MimeType": "image/jpeg"
+          },
+          {
+            "URL": "s3://nsidc-cumulus-prod-public/ATLAS/ATL08/005/2018/11/05/ATL08_20181105083647_05760107_005_01_BRW.gt3r.groundtrack.jpg",
+            "Type": "GET RELATED VISUALIZATION",
+            "MimeType": "image/jpeg"
+          },
+          {
+            "URL": "s3://nsidc-cumulus-prod-public/ATLAS/ATL08/005/2018/11/05/ATL08_20181105083647_05760107_005_01_BRW.gt3r.h_canopy_abs.jpg",
+            "Type": "GET RELATED VISUALIZATION",
+            "MimeType": "image/jpeg"
+          },
+          {
+            "URL": "s3://nsidc-cumulus-prod-public/ATLAS/ATL08/005/2018/11/05/ATL08_20181105083647_05760107_005_01_BRW.gt3r.h_te_median.jpg",
+            "Type": "GET RELATED VISUALIZATION",
+            "MimeType": "image/jpeg"
+          },
+          {
+            "URL": "s3://nsidc-cumulus-prod-public/ATLAS/ATL08/005/2018/11/05/ATL08_20181105083647_05760107_005_01_BRW.gt3r.n_ca_photons.jpg",
+            "Type": "GET RELATED VISUALIZATION",
+            "MimeType": "image/jpeg"
+          },
+          {
+            "URL": "s3://nsidc-cumulus-prod-public/ATLAS/ATL08/005/2018/11/05/ATL08_20181105083647_05760107_005_01_BRW.gt3r.n_te_photons.jpg",
+            "Type": "GET RELATED VISUALIZATION",
+            "MimeType": "image/jpeg"
+          }
+        ],
+        "DataGranule": {
+          "DayNightFlag": "Unspecified",
+          "Identifiers": [
+            {
+              "Identifier": "ATL08_20181105083647_05760107_005_01.h5",
+              "IdentifierType": "ProducerGranuleId"
+            }
+          ],
+          "ProductionDateTime": "2021-09-05T19:15:06.000Z",
+          "ArchiveAndDistributionInformation": [
+            {
+              "Name": "Not provided",
+              "Size": 14.847737312316895,
+              "SizeUnit": "NA"
+            }
+          ]
+        },
+        "MetadataSpecification": {
+          "URL": "https://cdn.earthdata.nasa.gov/umm/granule/v1.6.4",
+          "Name": "UMM-G",
+          "Version": "1.6.4"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
<!-- Thanks for contributing 🎉! Please ensure the title neatly summarizes the proposed changes. -->

<!-- Overview -->

Closes #8 

### Example
<!-- A code blurb is best. Changes to features should include an example that is executable by a new user. -->

```python

@flow
def test_flow(download_path):
    earthdata_credentials = EarthdataCredentials("earthdata-block")

    granules = earthdata_search_data(
        earthdata_credentials
        count=1,
        short_name="ATL08",
        bounding_box=(-92.86, 16.26, -91.58, 16.97),
    )

    files = earthdata_download(
        earthdata_credentials, 
        granules=granules, 
        local_path=download_path
    )

    return granules, files

```

### Screenshots
<!--
Any relevant screenshots
  - The updated docs page from `mkdocs serve`.
  - Output from running the example.
  - Service integration test results.
-->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/giorgiobasile/prefect-eo/issues/new/choose) first.
- [x] Includes tests or only affects documentation.
- [x] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [x] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
- [x] Summarizes PR's changes in [CHANGELOG.md](https://github.com/giorgiobasile/prefect-eo/blob/main/CHANGELOG.md)
